### PR TITLE
[AbstractProject] Loading languages in multi-domain setup

### DIFF
--- a/src/Project/Traits/ServicesTrait.php
+++ b/src/Project/Traits/ServicesTrait.php
@@ -19,8 +19,8 @@ use Mds\PimPrint\CoreBundle\Service\ImageDimensions;
 use Mds\PimPrint\CoreBundle\Service\PluginParameters;
 use Mds\PimPrint\CoreBundle\Service\SpecialChars;
 use Mds\PimPrint\CoreBundle\Service\ThumbnailHelper;
-use Mds\PimPrint\CoreBundle\Service\UserHelper;
 use Pimcore\Http\RequestHelper;
+use Pimcore\Localization\LocaleServiceInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -31,13 +31,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 trait ServicesTrait
 {
-    /**
-     * UserHelper service.
-     *
-     * @var UserHelper
-     */
-    protected $userHelper;
-
     /**
      * ImageDimensions helper service.
      *
@@ -88,14 +81,11 @@ trait ServicesTrait
     protected $urlGenerator;
 
     /**
-     * Sets UserHelper service.
+     * LocaleService instance.
      *
-     * @param UserHelper $userHelper
+     * @var LocaleServiceInterface
      */
-    public function setUserHelper(UserHelper $userHelper)
-    {
-        $this->userHelper = $userHelper;
-    }
+    protected $localeService;
 
     /**
      * Sets PluginParameters helper service.
@@ -228,6 +218,16 @@ trait ServicesTrait
     }
 
     /**
+     * Sets LocaleService instance.
+     *
+     * @param LocaleServiceInterface $localeService
+     */
+    public function setLocaleService(LocaleServiceInterface $localeService)
+    {
+        $this->localeService = $localeService;
+    }
+
+    /**
      * Returns project configuration
      *
      * @return Config
@@ -263,9 +263,9 @@ trait ServicesTrait
             $this->imageDimensions,
             $this->specialChars,
             $this->pluginParams,
-            $this->userHelper,
             $this->thumbnailHelper,
             $this->config,
+            $this->localeService,
         ];
         foreach ($services as $service) {
             if (null === $service) {

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -15,11 +15,11 @@ services:
         calls:
             - [setRequestHelper, ['@pimcore.http.request_helper']]
             - [setPluginParams, ['@mds.pimprint.core.plugin_parameters']]
-            - [setUserHelper, ['@mds.pimprint.core.user_helper']]
             - [setImageDimensions, ['@mds.pimprint.core.image_dimensions']]
             - [setSpecialChars, ['@mds.pimprint.core.special_chars']]
             - [setThumbnailHelper, ['@mds.pimprint.core.thumbnail_helper']]
             - [setUrlGenerator, ['@cmf_routing.router']]
+            - [setLocaleService, ['@pimcore.locale']]
 
     #Helper services
     mds.pimprint.core.user_helper:


### PR DESCRIPTION
When using the bundle in a multi-domain setup we run into the following exception [here](https://github.com/mds-agenturgruppe/pimprint-core-bundle/blob/master/src/Project/AbstractProject.php#L167):

```log
Call to a member function isAdmin() on null
```

This is because the cookie is not present on all domains (e.g. domain1.com, domain2.com) and therefore `Tool\Admin::getCurrentUser()` returns `null`.

This pull request changes the way how the current locale is loaded (via current request). It introduces the Pimcore LocaleService into the ServicesTrait to do so and also returns all valid languages if no Pimcore user could be found.

If you need more info, please let me know – thank you!